### PR TITLE
Import old patches from `mbed-tfm-1.1` for TF-M v1.2 + Mbed OS integration

### DIFF
--- a/readme.rst
+++ b/readme.rst
@@ -10,6 +10,13 @@ as the TF-M core and various secure partitions.
 There is also the `psa-arch-tests`_ suite which mainly focuses on the
 implementation compliance of the Platform Security Architecture(PSA).
 
+#######################################
+Mbed OS + Trusted Firmware-M Tests v1.2
+#######################################
+
+This specific branch supports additional patches required for integration
+of Mbed OS with Trusted Firmware-M Tests v1.2 implementation.
+
 ****************
 Folder Structure
 ****************

--- a/test/framework/test_framework.h
+++ b/test/framework/test_framework.h
@@ -14,6 +14,7 @@
 
 #include "tfm_log_raw.h"
 #include "test_framework_helpers.h"
+#include "test_framework_error_codes.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -64,17 +65,6 @@ struct test_suite_t {
     uint32_t list_size;            /*!< List size */
     const char *name;              /*!< Test suite name */
     enum test_status_t val;        /*!< Test suite result \ref test_result_t */
-};
-
-enum test_suite_err_t {
-    TEST_SUITE_ERR_NO_ERROR = 0,           /*!< No error */
-    TEST_SUITE_ERR_INVALID_DATA = 1,       /*!< Invalid test suite if any of the
-                                            *   pointers is NULL
-                                            */
-    TEST_SUITE_ERR_INVALID_TEST_DATA = 2,  /*!< Invalid test if any of the
-                                            *  pointers is NULL
-                                            */
-    TEST_SUITE_ERR_TEST_FAILED  = 3,       /*!< Last executed test has failed */
 };
 
 /**

--- a/test/framework/test_framework_error_codes.h
+++ b/test/framework/test_framework_error_codes.h
@@ -1,0 +1,22 @@
+/*
+ * Copyright (c) 2017-2019, Arm Limited. All rights reserved.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ *
+ */
+
+#ifndef __TEST_FRAMEWORK_ERROR_CODES_H__
+#define __TEST_FRAMEWORK_ERROR_CODES_H__
+
+enum test_suite_err_t {
+    TEST_SUITE_ERR_NO_ERROR = 0,           /*!< No error */
+    TEST_SUITE_ERR_INVALID_DATA = 1,       /*!< Invalid test suite if any of the
+                                            *   pointers is NULL
+                                            */
+    TEST_SUITE_ERR_INVALID_TEST_DATA = 2,  /*!< Invalid test if any of the
+                                            *  pointers is NULL
+                                            */
+    TEST_SUITE_ERR_TEST_FAILED  = 3,       /*!< Last executed test has failed */
+};
+
+#endif /* __TEST_FRAMEWORK_ERROR_CODES_H__ */

--- a/test/framework/test_framework_integ_test.h
+++ b/test/framework/test_framework_integ_test.h
@@ -8,7 +8,7 @@
 #ifndef __INTEG_TEST_H__
 #define __INTEG_TEST_H__
 
-#include "test_framework.h"
+#include "test_framework_error_codes.h"
 
 #ifdef __cplusplus
 extern "C" {

--- a/test/suites/multi_core/CMakeLists.txt
+++ b/test/suites/multi_core/CMakeLists.txt
@@ -13,6 +13,9 @@ endif()
 
 add_library(tfm_test_suite_multi_core_ns STATIC EXCLUDE_FROM_ALL)
 
+#CMSIS
+include_directories(${TFM_TEST_REPO_PATH}/CMSIS/RTOS2/Include ABSOLUTE)
+
 target_sources(tfm_test_suite_multi_core_ns
     PRIVATE
         non_secure/multi_core_ns_interface_testsuite.c

--- a/test/suites/multi_core/non_secure/multi_core_ns_interface_testsuite.c
+++ b/test/suites/multi_core/non_secure/multi_core_ns_interface_testsuite.c
@@ -7,14 +7,12 @@
 
 #include <stdbool.h>
 #include <stdint.h>
-#include "os_wrapper/mutex.h"
-#include "os_wrapper/thread.h"
-#include "os_wrapper/tick.h"
 #include "psa/client.h"
 #include "psa/internal_trusted_storage.h"
 #include "psa_manifest/sid.h"
 #include "test_framework_helpers.h"
 #include "tfm_ns_mailbox.h"
+#include "cmsis_os2.h"
 
 #ifdef TFM_MULTI_CORE_MULTI_CLIENT_CALL
 /* Max number of child threads for multiple outstanding PSA client call test */
@@ -93,13 +91,13 @@ static void wait_child_thread_completion(struct test_params *params_array,
 {
     bool is_complete;
     uint8_t i;
-    void *mutex = params_array[0].mutex_handle;
+    osMutexId_t mutex = params_array[0].mutex_handle;
 
     for (i = 0; i < child_idx; i++) {
         while (1) {
-            os_wrapper_mutex_acquire(mutex, OS_WRAPPER_WAIT_FOREVER);
+            osMutexAcquire(mutex, osWaitForever);
             is_complete = params_array[i].is_complete;
-            os_wrapper_mutex_release(mutex);
+            osMutexRelease(mutex);
 
             if (is_complete) {
                 break;
@@ -109,46 +107,62 @@ static void wait_child_thread_completion(struct test_params *params_array,
 }
 
 static void multi_client_call_test(struct test_result_t *ret,
-                                   os_wrapper_thread_func test_runner,
+                                   osThreadFunc_t test_runner,
                                    int32_t stack_size,
                                    int32_t nr_rounds,
                                    bool is_mixed)
 {
     uint8_t i, nr_child;
-    void *current_thread_handle;
-    uint32_t current_thread_priority, err, total_ticks, total_calls, avg_ticks;
-    void *mutex_handle;
-    void *child_ids[NR_MULTI_CALL_CHILD];
+    osThreadId_t current_thread_handle;
+    osPriority_t current_thread_priority;
+    osMutexId_t mutex_handle;
+    osThreadId_t child_ids[NR_MULTI_CALL_CHILD];
+    uint32_t total_ticks, total_calls, avg_ticks;
     struct ns_mailbox_stats_res_t stats_res;
     struct test_params parent_params, params[NR_MULTI_CALL_CHILD];
+    const osMutexAttr_t attr = {
+        .name = NULL,
+        .attr_bits = osMutexPrioInherit, /* Priority inheritance is recommended
+                                          * to enable if it is supported.
+                                          * For recursive mutex and the ability
+                                          * of auto release when owner being
+                                          * terminated is not required.
+                                          */
+        .cb_mem = NULL,
+        .cb_size = 0U
+    };
+    osThreadAttr_t task_attribs = {
+        .tz_module = 1,
+        .stack_size = stack_size,
+    };
 
     tfm_ns_mailbox_tx_stats_init();
 
-    current_thread_handle = os_wrapper_thread_get_handle();
+    current_thread_handle = osThreadGetId();
     if (!current_thread_handle) {
         TEST_FAIL("Failed to get current thread ID\r\n");
         return;
     }
 
-    err = os_wrapper_thread_get_priority(current_thread_handle,
-                                         &current_thread_priority);
-    if (err == OS_WRAPPER_ERROR) {
+    current_thread_priority = osThreadGetPriority(current_thread_handle);
+    if (current_thread_priority == osPriorityError) {
         TEST_FAIL("Failed to get current thread priority\r\n");
         return;
     }
+    task_attribs.priority = current_thread_priority;
 
     /*
      * Create a mutex to protect the synchronization between child test thread
      * about the completion status.
-     * The best way is to use os_wrapper_thread_wait/set_flag(). However, due to
-     * the implementation of the wait event functions in some RTOS, if the
-     * child test threads already exit before the main thread starts to wait for
+     * The best way is to use osThreadFlagsWait/Set(). However, due to the
+     * implementation of the wait event functions in some RTOS, if the child
+     * test threads already exit before the main thread starts to wait for
      * event (main thread itself has to perform test too), the main thread
      * cannot receive the event flags.
      * As a result, use a flag and a mutex to make sure the main thread can
      * capture the completion event of child threads.
      */
-    mutex_handle = os_wrapper_mutex_create();
+    mutex_handle = osMutexNew(&attr);
     if (!mutex_handle) {
         TEST_FAIL("Failed to create a mutex\r\n");
         return;
@@ -163,11 +177,7 @@ static void multi_client_call_test(struct test_result_t *ret,
         params[i].is_complete = false;
         params[i].is_parent = false;
 
-        child_ids[i] = os_wrapper_thread_new(NULL,
-                                             stack_size,
-                                             test_runner,
-                                             &params[i],
-                                             current_thread_priority);
+        child_ids[i] = osThreadNew(test_runner, &params[i], &task_attribs);
         if (!child_ids[i]) {
             break;
         }
@@ -184,7 +194,7 @@ static void multi_client_call_test(struct test_result_t *ret,
      * Try to make test threads to run together.
      */
     for (i = 0; i < nr_child; i++) {
-        os_wrapper_thread_set_flag(child_ids[i], TEST_CHILD_EVENT_FLAG(i));
+        osThreadFlagsSet(child_ids[i], TEST_CHILD_EVENT_FLAG(i));
     }
 
     /* Use current thread to execute a test instance */
@@ -196,7 +206,7 @@ static void multi_client_call_test(struct test_result_t *ret,
     /* Wait for all the test threads completes */
     wait_child_thread_completion(params, nr_child);
 
-    os_wrapper_mutex_delete(mutex_handle);
+    osMutexDelete(mutex_handle);
 
     if (parent_params.ret != TEST_PASSED) {
         ret->val = TEST_FAILED;
@@ -237,7 +247,7 @@ enum test_status_t multi_client_call_light_loop(struct test_params *params)
     uint32_t i, version, total_ticks;
     uint32_t nr_rounds = params->nr_rounds;
 
-    total_ticks = os_wrapper_get_tick();
+    total_ticks = osKernelGetTickCount();
 
     for (i = 0; i < nr_rounds; i++) {
         version = psa_framework_version();
@@ -247,7 +257,7 @@ enum test_status_t multi_client_call_light_loop(struct test_params *params)
         }
     }
 
-    params->total_ticks = os_wrapper_get_tick() - total_ticks;
+    params->total_ticks = osKernelGetTickCount() - total_ticks;
     params->nr_calls = nr_rounds;
 
     return TEST_PASSED;
@@ -259,17 +269,18 @@ static void multi_client_call_light_runner(void *argument)
 
     if (!params->is_parent) {
         /* Wait for the signal to kick-off the test */
-        os_wrapper_thread_wait_flag(TEST_CHILD_EVENT_FLAG(params->child_idx),
-                                    OS_WRAPPER_WAIT_FOREVER);
+        osThreadFlagsWait(TEST_CHILD_EVENT_FLAG(params->child_idx),
+                          osFlagsWaitAll,
+                          osWaitForever);
     }
 
     params->ret = multi_client_call_light_loop(params);
 
     if (!params->is_parent) {
         /* Mark this child thread has completed */
-        os_wrapper_mutex_acquire(params->mutex_handle, OS_WRAPPER_WAIT_FOREVER);
+        osMutexAcquire(params->mutex_handle, osWaitForever);
         params->is_complete = true;
-        os_wrapper_mutex_release(params->mutex_handle);
+        osMutexRelease(params->mutex_handle);
     }
 }
 
@@ -295,7 +306,7 @@ enum test_status_t multi_client_call_heavy_loop(const psa_storage_uid_t uid,
     char rd_data[ITS_DATA_LEN];
     const psa_storage_create_flags_t flags = PSA_STORAGE_FLAG_NONE;
 
-    total_ticks = os_wrapper_get_tick();
+    total_ticks = osKernelGetTickCount();
 
     for (i = 0; i < rounds; i++) {
         /* Set a data in the asset */
@@ -320,7 +331,7 @@ enum test_status_t multi_client_call_heavy_loop(const psa_storage_uid_t uid,
         }
     }
 
-    params->total_ticks = os_wrapper_get_tick() - total_ticks;
+    params->total_ticks = osKernelGetTickCount() - total_ticks;
     params->nr_calls = rounds * 3;
 
     return TEST_PASSED;
@@ -333,17 +344,18 @@ static void multi_client_call_heavy_runner(void *argument)
 
     if (!params->is_parent) {
         /* Wait for the signal to kick-off the test */
-        os_wrapper_thread_wait_flag(TEST_CHILD_EVENT_FLAG(params->child_idx),
-                                    OS_WRAPPER_WAIT_FOREVER);
+        osThreadFlagsWait(TEST_CHILD_EVENT_FLAG(params->child_idx),
+                          osFlagsWaitAll,
+                          osWaitForever);
     }
 
     params->ret = multi_client_call_heavy_loop(uid, params);
 
     if (!params->is_parent) {
         /* Mark this child thread has completed */
-        os_wrapper_mutex_acquire(params->mutex_handle, OS_WRAPPER_WAIT_FOREVER);
+        osMutexAcquire(params->mutex_handle, osWaitForever);
         params->is_complete = true;
-        os_wrapper_mutex_release(params->mutex_handle);
+        osMutexRelease(params->mutex_handle);
     }
 }
 
@@ -366,8 +378,9 @@ static void multi_client_call_ooo_runner(void *argument)
 
     if (!params->is_parent) {
         /* Wait for the signal to kick-off the test */
-        os_wrapper_thread_wait_flag(TEST_CHILD_EVENT_FLAG(params->child_idx),
-                                    OS_WRAPPER_WAIT_FOREVER);
+        osThreadFlagsWait(TEST_CHILD_EVENT_FLAG(params->child_idx),
+                                    osFlagsWaitAll,
+                                    osWaitForever);
     }
 
     if (!params->child_idx % 2) {
@@ -379,9 +392,9 @@ static void multi_client_call_ooo_runner(void *argument)
 
     if (!params->is_parent) {
         /* Mark this child thread has completed */
-        os_wrapper_mutex_acquire(params->mutex_handle, OS_WRAPPER_WAIT_FOREVER);
+        osMutexAcquire(params->mutex_handle, osWaitForever);
         params->is_complete = true;
-        os_wrapper_mutex_release(params->mutex_handle);
+        osMutexRelease(params->mutex_handle);
     }
 }
 

--- a/test/suites/ps/CMakeLists.txt
+++ b/test/suites/ps/CMakeLists.txt
@@ -11,6 +11,9 @@ if (NOT TFM_PARTITION_PROTECTED_STORAGE)
     return()
 endif()
 
+#CMSIS
+include_directories(${TFM_TEST_REPO_PATH}/CMSIS/RTOS2/Include ABSOLUTE)
+
 ####################### Non Secure #############################################
 
 add_library(tfm_test_suite_ps_ns STATIC EXCLUDE_FROM_ALL)

--- a/test/suites/ps/non_secure/ns_test_helpers.c
+++ b/test/suites/ps/non_secure/ns_test_helpers.c
@@ -7,10 +7,8 @@
 
 #include "ns_test_helpers.h"
 
-#include "os_wrapper/thread.h"
-#include "os_wrapper/semaphore.h"
-
 #include "tfm_nspm_api.h"
+#include "cmsis_os2.h"
 
 #define PS_TEST_TASK_STACK_SIZE (768)
 
@@ -19,7 +17,7 @@ struct test_task_t {
     struct test_result_t *ret;
 };
 
-static void *test_semaphore;
+static osSemaphoreId_t test_semaphore;
 
 /**
  * \brief Executes the supplied test task and then releases the test semaphore.
@@ -39,61 +37,66 @@ static void test_task_runner(void *arg)
     test->func(test->ret);
 
     /* Release the semaphore to unblock the parent thread */
-    os_wrapper_semaphore_release(test_semaphore);
+    osSemaphoreRelease(test_semaphore);
 
     /* Signal to the RTOS that the thread is finished */
-    os_wrapper_thread_exit();
+    osThreadExit();
 }
 
 void tfm_ps_run_test(const char *thread_name, struct test_result_t *ret,
                      test_func_t *test_func)
 {
-    void *current_thread_handle;
-    uint32_t current_thread_priority;
-    uint32_t err;
-    void *thread;
+    osThreadId_t current_thread_handle;
+    osPriority_t current_thread_priority;
+    osThreadId_t thread;
     struct test_task_t test_task = { .func = test_func, .ret = ret };
+    osSemaphoreAttr_t sema_attrib = {
+        .name = "ps_tests_sema",
+    };
+    osThreadAttr_t task_attribs = {
+        .tz_module = 1,
+        .name = thread_name,
+        .stack_size = PS_TEST_TASK_STACK_SIZE,
+    };
 
     /* Create a binary semaphore with initial count of 0 tokens available */
-    test_semaphore = os_wrapper_semaphore_create(1, 0, "ps_tests_sema");
+    test_semaphore = osSemaphoreNew(1, 0, &sema_attrib);
     if (!test_semaphore) {
         TEST_FAIL("Semaphore creation failed");
         return;
     }
 
-    current_thread_handle = os_wrapper_thread_get_handle();
+    current_thread_handle = osThreadGetId();
     if (!current_thread_handle) {
-        os_wrapper_semaphore_delete(test_semaphore);
+        osSemaphoreDelete(test_semaphore);
         TEST_FAIL("Failed to get current thread ID");
         return;
     }
 
-    err = os_wrapper_thread_get_priority(current_thread_handle,
-                                         &current_thread_priority);
-    if (err == OS_WRAPPER_ERROR) {
-        os_wrapper_semaphore_delete(test_semaphore);
+    current_thread_priority = osThreadGetPriority(current_thread_handle);
+    if (current_thread_priority == osPriorityError) {
+        osSemaphoreDelete(test_semaphore);
         TEST_FAIL("Failed to get current thread priority");
         return;
     }
+    task_attribs.priority = current_thread_priority;
 
     /* Start test thread */
-    thread = os_wrapper_thread_new(thread_name, PS_TEST_TASK_STACK_SIZE,
-                                   test_task_runner, &test_task,
-                                   current_thread_priority);
+    thread = osThreadNew(test_task_runner, &test_task, &task_attribs);
     if (!thread) {
-        os_wrapper_semaphore_delete(test_semaphore);
+        osSemaphoreDelete(test_semaphore);
         TEST_FAIL("Failed to create test thread");
         return;
     }
 
     /* Signal semaphore, wait indefinitely until unblocked by child thread */
-    err = os_wrapper_semaphore_acquire(test_semaphore, OS_WRAPPER_WAIT_FOREVER);
+    osSemaphoreAcquire(test_semaphore, osWaitForever);
 
     /* At this point, it means the binary semaphore has been released by the
      * test and re-acquired by this thread, so just finally release it and
      * delete it
      */
-    os_wrapper_semaphore_release(test_semaphore);
+    osSemaphoreRelease(test_semaphore);
 
-    os_wrapper_semaphore_delete(test_semaphore);
+    osSemaphoreDelete(test_semaphore);
 }


### PR DESCRIPTION
These patches have been imported from TFM v1.1 to get the integration work going for TFM v1.2

These can be referred here - https://github.com/ARMmbed/trusted-firmware-m/compare/mbed-tfm-1.1