### PR TITLE
Deprecated: add tests for getting/setting key algorithms

### DIFF
--- a/test/suites/crypto/crypto_tests_common.h
+++ b/test/suites/crypto/crypto_tests_common.h
@@ -164,6 +164,14 @@ void psa_invalid_key_length_test(struct test_result_t *ret);
 void psa_policy_key_interface_test(struct test_result_t *ret);
 
 /**
+ * \brief Tests the key enrollment policy interface
+ *
+ * \param[out] ret Test result
+ *
+ */
+void psa_enrollment_algorithm_interface_test(struct test_result_t *ret);
+
+/**
  * \brief Tests invalid policy usage
  *
  * \param[out] ret Test result

--- a/test/suites/crypto/non_secure/crypto_ns_interface_testsuite.c
+++ b/test/suites/crypto/non_secure/crypto_ns_interface_testsuite.c
@@ -56,6 +56,7 @@ static void tfm_crypto_test_6037(struct test_result_t *ret);
 #ifdef TFM_CRYPTO_TEST_HKDF
 static void tfm_crypto_test_6038(struct test_result_t *ret);
 #endif /* TFM_CRYPTO_TEST_HKDF */
+static void tfm_crypto_test_6039(struct test_result_t *ret);
 
 static struct test_t crypto_tests[] = {
     {&tfm_crypto_test_6001, "TFM_CRYPTO_TEST_6001",
@@ -131,6 +132,8 @@ static struct test_t crypto_tests[] = {
     {&tfm_crypto_test_6038, "TFM_CRYPTO_TEST_6038",
      "Non Secure HKDF key derivation", {TEST_PASSED} },
 #endif /* TFM_CRYPTO_TEST_HKDF */
+    {&tfm_crypto_test_6039, "TFM_CRYPTO_TEST_6039",
+     "Non Secure key enrollment policy interface", {TEST_PASSED} },
 };
 
 void register_testsuite_ns_crypto_interface(struct test_suite_t *p_test_suite)
@@ -305,3 +308,8 @@ static void tfm_crypto_test_6038(struct test_result_t *ret)
     psa_key_derivation_test(PSA_ALG_HKDF(PSA_ALG_SHA_256), ret);
 }
 #endif /* TFM_CRYPTO_TEST_HKDF */
+
+static void tfm_crypto_test_6039(struct test_result_t *ret)
+{
+    psa_enrollment_algorithm_interface_test(ret);
+}

--- a/test/suites/crypto/secure/crypto_sec_interface_testsuite.c
+++ b/test/suites/crypto/secure/crypto_sec_interface_testsuite.c
@@ -58,6 +58,7 @@ static void tfm_crypto_test_5038(struct test_result_t *ret);
 #ifdef TFM_CRYPTO_TEST_HKDF
 static void tfm_crypto_test_5039(struct test_result_t *ret);
 #endif /* TFM_CRYPTO_TEST_HKDF */
+static void tfm_crypto_test_5040(struct test_result_t *ret);
 
 static struct test_t crypto_tests[] = {
     {&tfm_crypto_test_5001, "TFM_CRYPTO_TEST_5001",
@@ -135,6 +136,8 @@ static struct test_t crypto_tests[] = {
     {&tfm_crypto_test_5039, "TFM_CRYPTO_TEST_5039",
      "Secure HKDF key derivation", {TEST_PASSED} },
 #endif /* TFM_CRYPTO_TEST_HKDF */
+    {&tfm_crypto_test_5040, "TFM_CRYPTO_TEST_5040",
+     "Secure key enrollment policy interface", {TEST_PASSED} },
 };
 
 void register_testsuite_s_crypto_interface(struct test_suite_t *p_test_suite)
@@ -349,3 +352,8 @@ static void tfm_crypto_test_5039(struct test_result_t *ret)
     psa_key_derivation_test(PSA_ALG_HKDF(PSA_ALG_SHA_256), ret);
 }
 #endif /* TFM_CRYPTO_TEST_HKDF */
+
+static void tfm_crypto_test_5040(struct test_result_t *ret)
+{
+    psa_enrollment_algorithm_interface_test(ret);
+}


### PR DESCRIPTION
In the ARMmbed/trusted-firmware-m repo, we addded `psa_set_key_algorithm()` and `psa_get_key_algorithm()` for backward compatibility. This commit adds tests for them.

Warning: The API to set and get the key algorithm are deprecated.

Verified with regression tests on Musca S1 along with https://github.com/ARMmbed/mbed-os/pull/14241 and https://github.com/ARMmbed/trusted-firmware-m/pull/14